### PR TITLE
Allow users to specify custom environment variable to override default API Key environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ steps:
           server: "${MY_OCTOPUS_SERVER}"
 ```
 
+## Configuring
+
+### `OCTOPUS_CLI_SERVER`
+
+Your Octopus Server URL should be set to this environment variable, or you can use `server` in the steps of your pipeline instead.
+
+### `OCTOPUS_CLI_API_KEY`
+
+Your Octopus Server API key should be set to this environment variable, either in your pipeline’s environment variable settings or exposed in an [environment hook](https://buildkite.com/docs/pipelines/secrets#storing-secrets-in-environment-hooks). If you need different keys for different steps in your pipeline use `api_key` instead.
+
 ## 📥 Inputs
 
 **The following inputs are required:**
@@ -64,7 +74,7 @@ steps:
 
 | Name                           | Description                                                                                                                                                                                                                                                          |  Default   |
 | :----------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------: |
-| `api_key`                      | The API key used to access Octopus Deploy. You must provide an API key or set the `OCTOPUS_CLI_API_KEY` environment variable. If the guest account is enabled, a key of API-GUEST may be used. It is strongly recommended that this value retrieved from an environment variable.
+| `api_key`                      | The environment variable that is configured with your Octopus Server API key used to access Octopus Deploy. Use this if you need to specify different keys for different steps in your pipeline.
 | `config_file`                  | The path to a configuration file of default values with one `key=value` per line.                                                                                                                                                                                    |            |
 | `debug`                        | Enable debug logging.                                                                                                                                                                                                                                                |  `false`   |
 | `ignore_ssl_errors`            | Ignore certificate errors when communicating with Octopus Deploy. Warning: enabling this option creates a security vulnerability.                                                                                                                                    |  `false`   |

--- a/hooks/command
+++ b/hooks/command
@@ -114,14 +114,14 @@ fi
 args=()
 maskedArgs=()
 #server:
-if [[ -n "${BUILDKITE_PLUGIN_CREATE_RELEASE_SERVER:-}" ]]; then
-    args+=( "--server" "${BUILDKITE_PLUGIN_CREATE_RELEASE_SERVER}" )
-    maskedArgs+=( "--server" "${BUILDKITE_PLUGIN_CREATE_RELEASE_SERVER}" )
+if [[ -n "${BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_SERVER:-}" ]]; then
+    args+=( "--server" "${BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_SERVER}" )
+    maskedArgs+=( "--server" "${BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_SERVER}" )
 fi
 
 #api_key:
-if [[ -n "${BUILDKITE_PLUGIN_CREATE_RELEASE_API_KEY:-}" ]]; then
-    args+=( "--apiKey" "${BUILDKITE_PLUGIN_CREATE_RELEASE_API_KEY}" )
+if [[ -n "${BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_API_KEY:-}" ]]; then
+    args+=( "--apiKey" "$(eval "echo \$${BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_API_KEY}")" )
     maskedArgs+=( "--apiKey" "SECRET" )
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,7 +7,7 @@ configuration:
   properties:
     api_key:
       type: string
-      description: 'The API key used to access Octopus Deploy. You must provide an API key or set the `OCTOPUS_CLI_API_KEY` environment variable. If the guest account is enabled, a key of API-GUEST may be used. It is strongly recommended that this value retrieved from an environment variable.'
+      description: 'Specifies the environment variable containing the Octopus Server API key'
     config_file:
       type: string
       description: 'The path to a configuration file of default values with one "key=value" per line.'

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -66,3 +66,40 @@ load "$BATS_PATH/load.bash"
     unset BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_PACKAGES_1
     unset BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_PACKAGE_VERSION
 }
+
+@test "Running push build information command overriding Server URL and API Key" {
+    export FAKE_API_KEY="API-123"
+    export BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_API_KEY="FAKE_API_KEY"
+    export BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_SERVER="https://octopus.example"
+    export BUILDKITE_BRANCH="main"
+    export BUILDKITE_BUILD_NUMBER="1541"
+    export BUILDKITE_BUILD_URL="https://buildkite.com/acme-inc/my-project/builds/1514"
+    export BUILDKITE_REPO="git@github.com:acme-inc/my-project.git"
+    export BUILDKITE_COMMIT="83a20ec058e2fb00e7fa4558c4c6e81e2dcf253d"
+    export BUILDKITE_BUILD_CHECKOUT_PATH="/tmp"
+
+    export BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_PACKAGES="MyApp.Web"
+    export BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_PACKAGE_VERSION="1.0.0"
+
+    stub octo "build-information --file /tmp/octopus.buildinfo --version 1.0.0 --package-id MyApp.Web --server https://octopus.example --apiKey API-123 : echo octo command ran"
+
+    run $PWD/hooks/command
+
+    assert_output --partial "octo command ran"
+    assert_success
+
+    unstub octo
+
+    unset FAKE_API_KEY
+    unset BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_API_KEY
+    unset BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_SERVER
+
+    unset BUILDKITE_BRANCH
+    unset BUILDKITE_BUILD_NUMBER
+    unset BUILDKITE_BUILD_URL
+    unset BUILDKITE_REPO
+    unset BUILDKITE_COMMIT
+
+    unset BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_PACKAGES
+    unset BUILDKITE_PLUGIN_PUSH_BUILD_INFORMATION_PACKAGE_VERSION
+}


### PR DESCRIPTION
> Plugins directly interpolate the API key into the `pipeline.yml`, which means there’s a risk of it being logged and passed around.

This PR is to address the above feedback from Buildkite about how we allowed users to enter their API keys directly in the yaml for our plugin