### PR TITLE
Add a limitations section to readme

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     container:
-      image: buildkite/plugin-tester:v1.1.0
+      image: buildkite/plugin-tester:v4.1.0
       volumes:
         - "${{github.workspace}}:/plugin"
     steps:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ More information about build information in Octopus Deploy:
 - [Build information](https://octopus.com/docs/packaging-applications/build-servers/build-information)
 - [Push build information](https://octopus.com/docs/octopus-rest-api/octopus-cli/build-information)
 
+## Limitations
+
+Due to limitations in what details are made available to plugins in Buildkite, we are unable to include any commit details in the build information that is pushed to Octopus.
+
 ## Examples
 
 Incorporate the following step in your `pipeline.yml` to create a release in Octopus Deploy:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ When deploying a release, it is useful to know which build produced the artifact
 Build information is associated with a package and includes:
 
 - Build URL: A link to the build which produced the package.
-- Commits: Details of the source commits related to the build.
-- Issues: Issue references parsed from the commit messages.
 
 More information about build information in Octopus Deploy:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     volumes:
       - ".:/plugin:ro"
   tests:
-    image: buildkite/plugin-tester:v1.1.0
+    image: buildkite/plugin-tester:v4.1.0
     volumes:
       - ".:/plugin:ro"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-    load "$BATS_PATH/load.bash"
+    load "$BATS_PLUGIN_PATH/load.bash"
 
     # Uncomment to enable stub debug output:
     # export OCTO_STUB_DEBUG=/dev/tty


### PR DESCRIPTION
Include that we cannot include commits in build info pushed to Octopus due to limitations of details provided to plugins

[sc-53690]